### PR TITLE
Enforce forward slashes for $GOPATH

### DIFF
--- a/gopath.go
+++ b/gopath.go
@@ -87,7 +87,7 @@ func LookupGopath(pkg string) (*PC, error) {
 	)
 	look := func(path, _, lib string) bool {
 		file := filepath.Join(lib, pkg+".pc")
-		vars["GOPATH"] = path
+		vars["GOPATH"] = filepath.ToSlash(path)
 		if f, err = os.Open(file); err == nil {
 			pc, err = NewPCVars(f, vars)
 			f.Close()


### PR DESCRIPTION
Under Windows, the `$GOPATH` variable might contain backslashes, which cgo ignores as part of its `CFLAGS` or `LDFLAGS`. They also clash with the forward slashes that tend to be used everywhere else in .pc files.